### PR TITLE
Remove JS extension from index file

### DIFF
--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -44,7 +44,7 @@ export const scaffoldComponent = async (source: Source = {}) => {
     if (existsSync(indexFilePath)) {
       const doAddToIndex = (await vscode.window.showInformationMessage('Add component to index.js file?', 'Yes Please', 'No Thanks')) === 'Yes Please'
       if (doAddToIndex) {
-        await appendFile(indexFilePath, `export { default as ${componentName} } from './${componentName}/${componentFileName}'\n`)
+        await appendFile(indexFilePath, `export { default as ${componentName} } from './${componentName}/${componentName}'\n`)
       }
     }
   }


### PR DESCRIPTION
Fixes #4 

Uses the `componentName` instead of `componentFileName` for the index file